### PR TITLE
add channel_keys option to dynamically join to channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Fluent plugin to send messages to IRC server
 |time_key|key name for time|time|
 |time_format|time format. This will be formatted with Time#strftime.|%Y/%m/%d %H:%M:%S|
 |tag_key|key name for tag|tag|
+|channel_keys|keys used to format channel. %s will be replaced with value specified by channel_keys if this option is used|nil|
 
 ## Copyright
 

--- a/test/plugin/test_out_irc.rb
+++ b/test/plugin/test_out_irc.rb
@@ -29,7 +29,7 @@ class IRCOutputTest < Test::Unit::TestCase
 
     assert_equal "localhost", d.instance.host
     assert_equal 6667, d.instance.port
-    assert_equal "fluentd", d.instance.channel
+    assert_equal "#fluentd", d.instance.channel
     assert_equal "fluentd", d.instance.nick
     assert_equal "fluentd", d.instance.user
     assert_equal "fluentd", d.instance.real
@@ -38,6 +38,11 @@ class IRCOutputTest < Test::Unit::TestCase
     assert_equal "time", d.instance.time_key
     assert_equal "%Y/%m/%d %H:%M:%S", d.instance.time_format
     assert_equal "tag", d.instance.tag_key
+
+    # channel_keys
+    d = create_driver(CONFIG + %[channel %s\nchannel_keys channel])
+    assert_equal "#%s", d.instance.channel
+    assert_equal ["channel"], d.instance.channel_keys
   end
 
   #def test_emit


### PR DESCRIPTION
I wanted to dynamically join to channels based on fluentd record. 

I added `channel_keys` option to achieve the objective.

* Without `channel_keys`, it will join to a channel specified by `channel` as before
* With `channel_keys`, `channel` format is expanded and join to the channel dynamically