### PR TITLE
Use queue and TimerWatcher to avoid Excess Flood

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Fluent plugin to send messages to IRC server
 |tag_key|key name for tag|tag|
 |command|irc command. `privmsg` or `notice`|privmsg|
 |command_keys|keys used to format command. %s will be replaced with value specified by command_keys if this option is used|nil|
+|send_interval|interval (sec) to send message. defence Excess Flood|2|
+|send_queue_limit|maximum size of send message queue|100|
 
 ## Copyright
 

--- a/lib/fluent/plugin/out_irc.rb
+++ b/lib/fluent/plugin/out_irc.rb
@@ -30,7 +30,9 @@ module Fluent
       val.split(',')
     end
 
-    config_param :blocking_timeout, :time, :default => 0.5
+    config_param :blocking_timeout, :time,    :default => 0.5
+    config_param :send_queue_limit, :integer, :default => 100
+    config_param :send_interval,    :time,    :default => 2
 
     COMMAND_MAP = {
       'priv_msg' => :priv_msg,
@@ -42,6 +44,8 @@ module Fluent
     unless method_defined?(:log)
       define_method("log") { $log }
     end
+
+    attr_reader :conn # for test
 
     def initialize
       super
@@ -77,6 +81,8 @@ module Fluent
           raise Fluent::ConfigError, "command must be one of #{COMMAND_MAP.keys.join(', ')}"
         end
       end
+
+      @send_queue = []
     end
 
     def start
@@ -85,6 +91,8 @@ module Fluent
       begin
         @loop = Coolio::Loop.new
         @conn = create_connection
+        @timer = TimerWatcher.new(@send_interval, true, log, &method(:on_timer))
+        @loop.attach(@timer)
         @thread = Thread.new(&method(:run))
       rescue => e
         puts e
@@ -116,9 +124,23 @@ module Fluent
       end
 
       es.each do |time,record|
+        if @send_queue.size >= @send_queue_limit
+          log.warn "out_irc: send queue size exceeded send_queue_limit(#{@send_queue_limit}), discards"
+          break
+        end
+
         filter_record(tag, time, record)
-        @conn.send_message(build_message(record), build_channel(record), build_command(record))
+        command, channel, message = build_command(record), build_channel(record), build_message(record)
+        log.debug { "out_irc: push {command:\"#{command}\", channel:\"#{channel}\", message:\"#{message}\"}" }
+        @send_queue.push([command, channel, message])
       end
+    end
+
+    def on_timer
+      return if @send_queue.empty?
+      command, channel, message = @send_queue.shift
+      log.info { "out_irc: send {command:\"#{command}\", channel:\"#{channel}\", message:\"#{message}\"}" }
+      @conn.send_message(command, channel, message)
     end
 
     private
@@ -167,7 +189,23 @@ module Fluent
       end
     end
 
+    class TimerWatcher < Coolio::TimerWatcher
+      def initialize(interval, repeat, log, &callback)
+        @callback = callback
+        @log = log
+        super(interval, repeat)
+      end
+
+      def on_timer
+        @callback.call
+      rescue
+        @log.error $!.to_s
+        @log.error_backtrace
+      end
+    end
+
     class IRCConnection < Cool.io::TCPSocket
+      attr_reader :joined # for test
       attr_accessor :log, :nick, :user, :real, :password
 
       def initialize(*args)
@@ -197,6 +235,7 @@ module Fluent
         data.each_line do |line|
           begin
             msg = IRCParser.parse(line)
+            log.debug { "out_irc: on_read :#{msg.class.to_sym}" }
             case msg.class.to_sym
             when :ping
               IRCParser.message(:pong) do |m|
@@ -204,6 +243,9 @@ module Fluent
                 m.body = msg.body
                 write m
               end
+            when :join
+              log.info { "out_irc: joined to #{msg.channels.join(', ')}" }
+              msg.channels.each {|channel| @joined[channel] = true }
             when :err_nick_name_in_use
               log.warn "out_irc: nickname \"#{msg.error_nick}\" is already in use."
             when :error
@@ -224,16 +266,17 @@ module Fluent
           m.channels = channel
           write m
         end
-        @joined[channel] = true
+        log.debug { "out_irc: join to #{channel}" }
       end
 
-      def send_message(msg, channel, command)
+      def send_message(command, channel, message)
         join(channel) unless joined?(channel)
         IRCParser.message(command) do |m|
           m.target = channel
-          m.body = msg
+          m.body = message
           write m
         end
+        channel # return channel for test
       end
     end
   end

--- a/test/plugin/test_out_irc.rb
+++ b/test/plugin/test_out_irc.rb
@@ -39,6 +39,8 @@ class IRCOutputTest < Test::Unit::TestCase
       time_key time
       time_format #{TIME_FORMAT}
       tag_key tag
+      send_queue_limit 10
+      send_interval 0.5
     ]
     config += %[command_keys #{command_keys}] if command_keys
     config
@@ -64,6 +66,8 @@ class IRCOutputTest < Test::Unit::TestCase
     assert_equal "time", d.instance.time_key
     assert_equal TIME_FORMAT, d.instance.time_format
     assert_equal "tag", d.instance.tag_key
+    assert_equal 10,  d.instance.send_queue_limit
+    assert_equal 0.5, d.instance.send_interval
   end
 
   def test_configure_channel_keys
@@ -95,22 +99,22 @@ class IRCOutputTest < Test::Unit::TestCase
 
     emit_test(msgs) do |socket|
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, :nick
-      assert_equal m.nick, NICK
+      assert_equal :nick, m.class.to_sym
+      assert_equal NICK, m.nick
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, :user
-      assert_equal m.user, USER
-      assert_equal m.postfix, REAL
+      assert_equal :user, m.class.to_sym
+      assert_equal USER, m.user
+      assert_equal REAL, m.postfix
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, :join
-      assert_equal m.channels, ["##{CHANNEL}"]
+      assert_equal :join, m.class.to_sym, :join
+      assert_equal ["##{CHANNEL}"], m.channels
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, COMMAND
-      assert_equal m.target, "##{CHANNEL}"
-      assert_equal m.body, body
+      assert_equal COMMAND, m.class.to_sym
+      assert_equal "##{CHANNEL}", m.target
+      assert_equal body, m.body
 
       assert_nil socket.gets # expects EOF
     end
@@ -133,24 +137,24 @@ class IRCOutputTest < Test::Unit::TestCase
       socket.gets # ignore USER
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, :join
-      assert_equal m.channels, ["#chan1"]
+      assert_equal :join, m.class.to_sym
+      assert_equal ["#chan1"], m.channels
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, COMMAND
-      assert_equal m.target, "#chan1"
+      assert_equal COMMAND, m.class.to_sym
+      assert_equal "#chan1", m.target
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, :join
-      assert_equal m.channels, ["#chan2"]
+      assert_equal :join, m.class.to_sym
+      assert_equal ["#chan2"], m.channels
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, COMMAND
-      assert_equal m.target, "#chan2"
+      assert_equal COMMAND, m.class.to_sym
+      assert_equal "#chan2", m.target
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, COMMAND
-      assert_equal m.target, "#chan1"
+      assert_equal COMMAND, m.class.to_sym
+      assert_equal "#chan1", m.target
 
       assert_nil socket.gets # expects EOF
     end
@@ -174,19 +178,19 @@ class IRCOutputTest < Test::Unit::TestCase
       socket.gets # ignore USER
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, :join
+      assert_equal :join, m.class.to_sym
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, :priv_msg
+      assert_equal :priv_msg, m.class.to_sym
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, :priv_msg
+      assert_equal :priv_msg, m.class.to_sym
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, :notice
+      assert_equal :notice, m.class.to_sym
 
       m = IRCParser.parse(socket.gets)
-      assert_equal m.class.to_sym, :priv_msg # replaced by default priv_msg
+      assert_equal :priv_msg, m.class.to_sym # replaced by default priv_msg
 
       assert_nil socket.gets # expects EOF
     end
@@ -208,6 +212,8 @@ class IRCOutputTest < Test::Unit::TestCase
       d.run do
         msgs.each do |m|
           d.emit(m, Fluent::Engine.now)
+          channel = d.instance.on_timer
+          d.instance.conn.joined[channel] = true # pseudo join
         end
         # How to remove sleep?
         # It is necessary to ensure that no data remains in Cool.io write buffer before detach.


### PR DESCRIPTION
To fix https://github.com/choplin/fluent-plugin-irc/issues/11

This approach is similar with what ikachan is doing. 

The default value of `send_queue_limit`, and `send_interval` was taken from ikachan implementation https://github.com/yappo/p5-AnySan/blob/117ab1f68feddd5b9b16236b30f8cfe75ba96129/lib/AnySan/Provider/IRC.pm#L197-L198

I intentionally differed the option name from `flush_interval` and `buffer_queue_limit` which BufferedOutput has because this plugin is not BufferedOutput plugin, but please let me know if you want to make them same.