### PR TITLE
Add a secret parameter

### DIFF
--- a/lib/fluent/plugin/out_irc.rb
+++ b/lib/fluent/plugin/out_irc.rb
@@ -17,7 +17,7 @@ module Fluent
     config_param :nick        , :string  , :default => 'fluentd'
     config_param :user        , :string  , :default => 'fluentd'
     config_param :real        , :string  , :default => 'fluentd'
-    config_param :password    , :string  , :default => nil
+    config_param :password    , :string  , :default => nil, :secret => true
     config_param :message     , :string
     config_param :out_keys do |val|
       val.split(',')


### PR DESCRIPTION
Fluentd's config_params now supports concealing given parameters with xxxxxx as below:

```log
  <source>
    type forward
  </source>
  <match **>
    type irc
    host localhost
    port 6667
    channel fluentd
    nick fluentd
    user fluentd
    real fluentd
    password xxxxxx
    message notice: %s [%s] %s
    out_keys tag,time,msg
    time_key time
    time_format %Y/%m/%d %H:%M:%S
    tag_key tag
    command priv_msg
  </match>
</ROOT>
```